### PR TITLE
changing direction

### DIFF
--- a/example/log2postgres.rb
+++ b/example/log2postgres.rb
@@ -7,33 +7,8 @@ file = sprintf('%s/log4r-postgres.yaml', File.dirname(__FILE__))
 Log4r::YamlConfigurator.load_yaml_file(file)
 
 logger  = Log4r::Logger.get('bar')
-logger2 = Log4r::Logger.get('bar')
 
-# these must be run before actually using the logger
-# TODO we also need to handle the case where our user/database don't exist
-dbh = logger.sequel(:configure, file)
-logger.sequel(:connect, dbh)
-
-dbh2 = logger2.sequel(:configure, {
-  :type   => :postgres,
-  :server => 'localhost',
-  :port   => 5432,
-  :username => 'postgres',
-  :password => 'postgres',
-  :database => 'logs',
-  :table    => 'logs', # TODO come up with some way to sanely differentiate between these twi
-  :delimiter => '!@#$',
-  # TODO let's use a different pattern here
-  :map => {
-    0 => 'date',
-    1 => 'level',
-    2 => 'class',
-    3 => 'message',
-  },
-})
-logger2.sequel(:connect, dbh2)
-
-[logger, logger2].each do |l|
+[logger].each do |l|
   ## log some garbage
   l.debug('this is a debug message')
   l.info('this is an info message')

--- a/example/log2sqlite.rb
+++ b/example/log2sqlite.rb
@@ -4,33 +4,15 @@ require 'sqlite3'
 
 #require 'log4r-sequel'
 require 'log4r/outputter/sequel'
+require 'log4r/yamlconfigurator'
 
 ## instantiate a logger following the log4r pattern
 file = sprintf('%s/log4r-sqlite.yaml', File.dirname(__FILE__))
 Log4r::YamlConfigurator.load_yaml_file(file)
 
 logger  = Log4r::Logger.get('foo')
-logger2 = Log4r::Logger.new('foo')
-# these must be run before using the logger
-dbh = logger.sequel(:configure, file)
-logger.sequel(:connect, dbh)
 
-dbh2 = logger2.sequel(:configure, {
-  :type => :sqlite,
-  :file => 'log2.sqlite',
-  :table => 'logs',
-  :delimiter => '!@#$',
-  :map => {
-    0 => 'date',
-    1 => 'level',
-    2 => 'class',
-    3 => 'message',
-  },
-})
-
-logger2.sequel(:connect, dbh2)
-
-[logger, logger2].each do |l|
+[logger].each do |l|
   ## log some garbage
   l.debug('this is a debug message')
   l.info('this is an info message')

--- a/example/log2sqlite.rb
+++ b/example/log2sqlite.rb
@@ -10,7 +10,7 @@ file = sprintf('%s/log4r-sqlite.yaml', File.dirname(__FILE__))
 Log4r::YamlConfigurator.load_yaml_file(file)
 
 logger  = Log4r::Logger.get('foo')
-logger2 = Log4r::Logger.get('foo')
+logger2 = Log4r::Logger.new('foo')
 # these must be run before using the logger
 dbh = logger.sequel(:configure, file)
 logger.sequel(:connect, dbh)

--- a/example/log4r-postgres.yaml
+++ b/example/log4r-postgres.yaml
@@ -15,12 +15,30 @@ log4r_config:
       pattern: '%d | %C | %l | %m'
 
   - type: SequelOutputter
+    # traditional Log4r settings
     name: sequel
     level: DEBUG
     formatter:
       type: PatternFormatter
       date_pattern: '%Y/%m/%d %H:%M.%s'
-      pattern: '%d!@#$%C!@#$%l!@#$%m' # date|level|event/class fullname|message
+      pattern: '%d!@#$%l!@#$%C!@#$%c!@#$%h!@#$%p!@#$%m' # kitchen sink
+    # log4r-sequel settings
+    engine: postgres
+    server: localhost
+    port: 5432
+    database: logs
+    table: logs
+    username: postgres
+    password: postgres
+    delimiter: '!@#$' # this is used to determine columns needed based on log4 configuration
+    map:
+      0: 'date'
+      1: 'level'
+      2: 'class'
+      3: 'relative_class'
+      4: 'thread'
+      5: 'pid'
+      6: 'message'
 
 # truncated map from http://log4r.rubyforge.org/rdoc/Log4r/PatternFormatter.html
 #  %c - event short name
@@ -33,18 +51,3 @@ log4r_config:
 #  %p - process ID aka PID
 #  %M - formatted message
 #  %l - Level in string form
-
-log4r_sequel_config:
-  type: :postgres
-  server: localhost
-  port: 5432
-  database: logs
-  table: logs
-  username: postgres
-  password: postgres
-  delimiter: '!@#$' # this is used to determine columns needed based on log4 configuration
-  map:
-    0: 'date'
-    1: 'level'
-    2: 'class'
-    3: 'message'

--- a/example/log4r-sqlite.yaml
+++ b/example/log4r-sqlite.yaml
@@ -15,12 +15,23 @@ log4r_config:
       pattern: '%d | %C | %l | %m'
 
   - type: SequelOutputter
+    # traditional Log4r settings
     name: sequel
     level: DEBUG
     formatter:
       type: PatternFormatter
       date_pattern: '%Y/%m/%d %H:%M.%s'
       pattern: '%d!@#$%C!@#$%l!@#$%m' # date|level|event/class fullname|message
+    # log4r-sequel settings
+    engine: sqlite
+    file: log.sqlite
+    table: logs
+    delimiter: '!@#$' # this is used to determine columns needed based on log4 configuration
+    map:
+      0: 'date'
+      1: 'level'
+      2: 'class'
+      3: 'message'
 
 # truncated map from http://log4r.rubyforge.org/rdoc/Log4r/PatternFormatter.html
 #  %c - event short name
@@ -33,14 +44,3 @@ log4r_config:
 #  %p - process ID aka PID
 #  %M - formatted message
 #  %l - Level in string form
-
-log4r_sequel_config:
-  type: :sqlite
-  file: log.sqlite
-  table: logs
-  delimiter: '!@#$' # this is used to determine columns needed based on log4 configuration
-  map:
-    0: 'date'
-    1: 'level'
-    2: 'class'
-    3: 'message'


### PR DESCRIPTION
- moving from requiring a `Log4r::YamlConfigurator` hack of requiring a special key to a more standard way of accepting input. this allows configure/connect to happen as soon as the containing `Log4r::Logger` object is instantiated
